### PR TITLE
解决在登录和注销界面下jsi18n导致js错误

### DIFF
--- a/xadmin/sites.py
+++ b/xadmin/sites.py
@@ -292,13 +292,8 @@ class AdminSite(object):
             return update_wrapper(wrapper, view)
 
         # Admin-site-wide views.
-        urlpatterns = patterns('',
-                               url(r'^jsi18n/$', wrap(self.i18n_javascript,
-                                                      cacheable=True), name='jsi18n')
-                               )
-
         # Registed admin views
-        urlpatterns += patterns('',
+        urlpatterns = patterns('',
                                 *[url(
                                   path, wrap(self.create_admin_view(clz_or_func)) if type(clz_or_func) == type and issubclass(clz_or_func, BaseAdminView) else include(clz_or_func(self)),
                                   name=name) for path, clz_or_func, name in self._registry_views]
@@ -323,19 +318,6 @@ class AdminSite(object):
     @property
     def urls(self):
         return self.get_urls(), self.name, self.app_name
-
-    def i18n_javascript(self, request):
-        """
-        Displays the i18n JavaScript that the Django admin requires.
-
-        This takes into account the USE_I18N setting. If it's set to False, the
-        generated JavaScript will be leaner and faster.
-        """
-        if settings.USE_I18N:
-            from django.views.i18n import javascript_catalog
-        else:
-            from django.views.i18n import null_javascript_catalog as javascript_catalog
-        return javascript_catalog(request, packages=['django.conf', 'xadmin'])
 
 # This global object represents the default admin site, for the common case.
 # You can instantiate AdminSite in your own code to create a custom admin site.

--- a/xadmin/views/__init__.py
+++ b/xadmin/views/__init__.py
@@ -7,7 +7,7 @@ from delete import DeleteAdminView
 from detail import DetailAdminView
 from form import FormAdminView
 from dashboard import Dashboard, BaseWidget, widget_manager, ModelDashboard
-from website import IndexView, LoginView, LogoutView, UserSettingView
+from website import IndexView, LoginView, LogoutView, UserSettingView, I18nView
 
 __all__ = (
     'BaseAdminObject',
@@ -23,6 +23,7 @@ def register_builtin_views(site):
     site.register_view(r'^$', IndexView, name='index')
     site.register_view(r'^login/$', LoginView, name='login')
     site.register_view(r'^logout/$', LogoutView, name='logout')
+    site.register_view(r'^jsi18n/$', I18nView, name='jsi18n')
 
     site.register_view(r'^settings/user$', UserSettingView, name='user_settings')
 

--- a/xadmin/views/website.py
+++ b/xadmin/views/website.py
@@ -4,6 +4,7 @@ from django.views.decorators.cache import never_cache
 from django.contrib.auth.views import login
 from django.contrib.auth.views import logout
 from django.http import HttpResponse
+from django.conf import settings
 
 from base import BaseAdminView, filter_hook
 from dashboard import Dashboard
@@ -94,3 +95,22 @@ class LogoutView(BaseAdminView):
     @never_cache
     def post(self, request, *args, **kwargs):
         return self.get(request)
+
+class I18nView(BaseAdminView):
+
+    need_site_permission = False
+
+    @never_cache
+    def get(self, request, *args, **kwargs):
+        context = self.get_context()
+        """
+        Displays the i18n JavaScript that the Django admin requires.
+
+        This takes into account the USE_I18N setting. If it's set to False, the
+        generated JavaScript will be leaner and faster.
+        """
+        if settings.USE_I18N:
+            from django.views.i18n import javascript_catalog
+        else:
+            from django.views.i18n import null_javascript_catalog as javascript_catalog
+        return javascript_catalog(request, packages=['django.conf', 'xadmin'])

--- a/xadmin/views/website.py
+++ b/xadmin/views/website.py
@@ -100,7 +100,6 @@ class I18nView(BaseAdminView):
 
     need_site_permission = False
 
-    @never_cache
     def get(self, request, *args, **kwargs):
         context = self.get_context()
         """


### PR DESCRIPTION
独立 jsi18n 到 xadmin/views/website.py，

加上 need_site_permission = False