### PR TITLE
Fix for when the 'source_attr' attribute is an unknown attribute.

### DIFF
--- a/xadmin/util.py
+++ b/xadmin/util.py
@@ -233,7 +233,7 @@ class NestedObjects(Collector):
 
     def collect(self, objs, source_attr=None, **kwargs):
         for obj in objs:
-            if source_attr:
+            if source_attr and hasattr(obj, source_attr):
                 self.add_edge(getattr(obj, source_attr), obj)
             else:
                 self.add_edge(None, obj)


### PR DESCRIPTION
xadmin [master]
django-taggit 0.18.0
django 1.7.11
python 2.7

I related groups with tags as shown below
```
# models.py

if not hasattr(Group, 'tags'):
    tags = TaggableManager(blank=True)
    tags.contribute_to_class(Group, 'tags')
```

I can create groups with tags no issues.

However when trying to delete the group ended up getting the error.

> 'TaggedItem' object has no attribute '+'

xadmin ignores the fact that the object having or not having the attribute: "+"
https://github.com/sshwsfc/django-xadmin/blob/master/xadmin/util.py#L237

The attribute "+" was extracted from the virtual field and passed to xadmin
https://github.com/django/django/blob/stable/1.7.x/django/db/models/deletion.py#L206


